### PR TITLE
経歴の画像の削除とローカルナビゲーションの持ち上げ、3カラム問題解決。

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div class="wrapper"></div>
+<div class="wrapper">
 <header class="header">
 <h1 class="title"><img src="C:/Users/AZUSA/Documents/GitHub/Create-My-Portfolio/Keep Going.png" alt="Azusa's Portfolio" width="1200" height="350">
 <nav class="nav">
@@ -19,29 +19,24 @@
 </h1>
 </header>
 <main>
-<h2 id="profile">Profile</h2>
-<h3 id="keireki">経歴</h3>
-<div class="profile-block">
-    <div class="profile-item">
-        <div class="photo">
-<p id="profile-photo"><img src="C:/Users/AZUSA/ポートフォリオ/使用画像/IMG_4778.jpg" alt="" width="250" height="300" class="profile-photo"></p>
-        </div>
-        <div class="profile-contents">
-<p id="keireki-text1"><strong>岡本 梓沙(オカモト アズサ)</strong></p>
-<p id="keireki-text2">1998年2月10日生まれ。兵庫県生まれ、兵庫県育ち。</p>
-<p id="keireki-text3">2020年3月、関西学院大学商学部卒業。</p>
-<p id="keireki-text4">大学では、金融を専攻。</p>
-        </div>
+<div class="flexbox">
+    <div class="side2">
+        <ul>
+            <li type="none"><a href="profile.html">経歴</a></li>
+            <li type="none"><a href="aisatsu.html">ごあいさつ</a></li>
+            <li type="none"><a href="shikaku.html">資格</a></li>
+        </ul>
     </div>
+<section class="profile">
+<h2>Profile</h2>
+<h3 >経歴</h3>
+<p class="keireki-text"><strong>岡本 梓沙(オカモト アズサ)</strong></p><br>
+<p class="keireki-text">1998年2月10日生まれ。兵庫県生まれ、兵庫県育ち。</p><br>
+<p class="keireki-text">2020年3月、関西学院大学商学部卒業。</p><br>
+<p class="keireki-text">大学では、金融を専攻。</p>
+</section>
 </div>
 </main><br>
-<div id="side2">
-    <ul>
-        <li type="none"><a href="profile.html">経歴</a></li>
-        <li type="none"><a href="aisatsu.html">ごあいさつ</a></li>
-        <li type="none"><a href="shikaku.html">資格</a></li>
-    </ul>
 </div>
-
 </body>
 </html>


### PR DESCRIPTION
#25 
#26 
経歴に載せていた画像は、やはり自分の画像ということもあり、掲載を断念。ローカルナビゲーションを上部に持ち上げた。
また、3カラムにしようとしていたが、画像を消すことになったので、2カラムのままにした。